### PR TITLE
Add German variant of `DateRangeParser`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,3 +6,4 @@
 
 ## 2023-08-xx 0.0.0
 - Initial thing, using `arbitrary-dateparser` and `DateRangeParser` packages
+- Add German variant of `DateRangeParser`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 Aika provides date- and time-range parsing utilities for multiple languages.
 It is based on [arbitrary-dateparser] and [DateRangeParser].
 
+Currently, it supports English and German, and welcomes contributions for
+other languages.
+
 
 ## Usage
 
@@ -36,7 +39,7 @@ a few examples.
 - jul 1 to jul 7
 - Sat - Tue
 
-#### DateRangeParser
+#### DateRangeParser » English
 
 - 1st july
 - March 2024
@@ -52,6 +55,14 @@ a few examples.
 - Jan 2011 - Mar 2014 
 - 07:00 Tue 7th June - 17th July 3:30pm
   <br>**Caveat**: Times will currently be ignored.
+
+#### DateRangeParser » German
+
+- 1\. Juli
+- 1\. bis 7. Juli
+- März 2024
+- Juli bis Dezember
+- Vom 3. März bis zum 9. März 2024
 
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ a few examples.
 
 #### arbitrary-dateparser
 
-- jul 1 to jul 7
+- now
+- today
 - last week to next friday
 - tomorrow - next week
 - next month
 - december
+- jul 1 to jul 7
 - Sat - Tue
 
 #### DateRangeParser
 
-- today
-- now
 - 1st july
 - March 2024
 - July to December

--- a/aika/core.py
+++ b/aika/core.py
@@ -8,6 +8,7 @@ import typing as t
 from arbitrary_dateparser import DateParser
 from daterangeparser import parse as drp_parse_english
 
+from .daterangeparser_german import parse_german as drp_parse_german
 from .model import Parser, trange
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ class DaterangeExpression:
     def use_all_parsers(self):
         self.parsers += [
             Parser(name="DateRangeParser [en]", fun=drp_parse_english),
+            Parser(name="DateRangeParser [de]", fun=drp_parse_german),
             Parser(name="arbitrary-dateparser [en]", fun=adp_parse_english),
         ]
 

--- a/aika/daterangeparser_german.py
+++ b/aika/daterangeparser_german.py
@@ -1,0 +1,197 @@
+# daterangeparser - a Python library to parse string date ranges
+# Copyright (C) 2013  Robin Wilson
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+
+from daterangeparser.parse_date_range import check_day, post_process
+from pyparsing import Group, Literal, Optional, ParseException, Word, nums, oneOf, stringEnd
+
+from aika.model import trange
+
+MONTHS = {
+    "jan": 1,
+    "januar": 1,
+    "feb": 2,
+    "februar": 2,
+    "mär": 3,
+    "märz": 3,
+    "maer": 3,
+    "maerz": 3,
+    "apr": 4,
+    "april": 4,
+    "mai": 5,
+    "jun": 6,
+    "juni": 6,
+    "jul": 7,
+    "juli": 7,
+    "aug": 8,
+    "august": 8,
+    "sep": 9,
+    "sept": 9,
+    "september": 9,
+    "okt": 10,
+    "oktober": 10,
+    "nov": 11,
+    "november": 11,
+    "dez": 12,
+    "dezember": 12,
+}
+
+
+def month_to_number(tokens):
+    """
+    Converts a given month in string format to the equivalent month number.
+
+    Works with strings in any case, both abbreviated (Jan) and full (January).
+    """
+    month_name = tokens[0].lower()
+    return MONTHS[month_name]
+
+
+def create_daterangeparser_german():
+    """Creates the parser using PyParsing functions."""
+
+    # Day details (day number, superscript and day name)
+    daynum = Word(nums, max=2)
+    day = oneOf("Mo Montag Di Dienstag Mi Mittwoch Do Donnerstag Fr Freitag Sa Samstag So Sonntag", caseless=True)
+
+    full_day_string = daynum + Optional(Literal(".").suppress())
+    full_day_string.setParseAction(check_day)
+    full_day_string.leaveWhitespace()
+
+    # Month names, with abbreviations, with action to convert to equivalent month number
+    month = oneOf(list(MONTHS.keys()), caseless=True) + Optional(Literal(".").suppress())
+    month.setParseAction(month_to_number)
+
+    # Year
+    year = Word(nums, exact=4)
+    year.setParseAction(lambda tokens: int(tokens[0]))
+
+    time_sep = oneOf(": .")
+    am_pm = oneOf("am pm", caseless=True)
+    hours = Word(nums, max=2)
+    mins = Word(nums, max=2)
+
+    time = hours("hour") + time_sep.suppress() + mins("mins") + Optional(am_pm)("meridian")
+
+    # date pattern
+    date = Group(
+        Optional(time).suppress()
+        & Optional(full_day_string("day"))
+        & Optional(day).suppress()
+        & Optional(month("month"))
+        & Optional(year("year"))
+    )
+
+    # Possible separators
+    separator = oneOf("- -- bis \u2013 \u2014 ->", caseless=True)
+
+    # Strings to completely ignore (whitespace ignored by default)
+    ignoreable_chars = oneOf(", von vom ab anfang zum", caseless=True)
+
+    # Final putting together of everything
+    daterange = (
+        Optional(date("start") + Optional(time).suppress() + separator.suppress())
+        + date("end")
+        + Optional(time).suppress()
+        + stringEnd()
+    )
+    daterange.ignore(ignoreable_chars)
+
+    return daterange
+
+
+def parse_german(text: str, allow_implicit: bool = True) -> trange:
+    """
+    Parses a date range string and returns the start and end as datetimes.
+
+    **Accepted formats:**
+
+    This parsing routine works with date ranges and single dates, and should
+    work with a wide variety of human-style string formats, including:
+
+    - 27th-29th June 2010
+    - 30 May to 9th Aug
+    - 3rd Jan 1980 - 2nd Jan 2013
+    - Wed 23 Jan - Sat 16 February 2013
+    - Tuesday 29 May -> Sat 2 June 2012
+    - From 27th to 29th March 1999
+    - 1--9 Jul
+    - 14th July 1988
+    - 23rd October 7:30pm
+    - From 07:30 18th Nov to 17:00 24th Nov
+
+    **Notes:**
+
+    - If an error encountered while parsing the date range then a
+    `pyparsing.ParseException` will be raised.
+    - If no year is specified then the current year is used.
+    - All day names are ignored, so there is no checking to see whether,
+    for example, the 23rd Jan 2013 is actually a Wednesday.
+    - All times are ignored, assuming they are placed either before or after
+    each date, otherwise they will cause an error.
+    - The separators that are allows as part of the date range are `to`,
+    `until`, `-`, `--` and `->`, plus the unicode em and en dashes.
+    - Other punctuation, such as commas, is ignored.
+
+    :param text: The string to parse
+    :param allow_implicit: If implicit dates are allowed. For example,
+    string 'May' by default treated as range
+           from May, 1st to May, 31th. Setting allow_implicit to False helps avoid it.
+    :return: A tuple ``(start, end)`` where each element is a datetime object.
+    If the string only defines a single date then the tuple is ``(date, None)``.
+    All times in the datetime objects are set to 00:00 as this function only parses dates.
+    """
+    parser = create_daterangeparser_german()
+
+    result = parser.parseString(text)
+    res = post_process(result, allow_implicit)
+
+    # Create standard dd/mm/yyyy strings and then convert to Python datetime
+    # objects
+    if "year" not in res.start:
+        # in case only separator was given
+        raise ParseException("Couldn't parse resulting datetime")
+
+    try:
+        start_str = "%(day)s/%(month)s/%(year)s" % res.start
+        start_datetime = datetime.datetime.strptime(start_str, "%d/%m/%Y")
+    except ValueError as ex:
+        raise ParseException("Couldn't parse resulting datetime") from ex
+
+    if res.end is None:
+        return start_datetime, None
+    elif not res.end:
+        raise ParseException("Couldn't parse resulting datetime")
+    else:
+        try:
+            if "month" not in res.end:
+                res.end["month"] = res.start["month"]
+            end_str = "%(day)s/%(month)s/%(year)s" % res.end
+            end_datetime = datetime.datetime.strptime(end_str, "%d/%m/%Y")
+        except ValueError as ex:
+            raise ParseException("Couldn't parse resulting datetime") from ex
+
+        if end_datetime < start_datetime:
+            # end is before beginning!
+            # This is probably caused by a date straddling the change of year
+            # without the year being given
+            # So, we assume that the start should be the previous year
+            res.start["year"] = res.start["year"] - 1
+            start_str = "%(day)s/%(month)s/%(year)s" % res.start
+            start_datetime = datetime.datetime.strptime(start_str, "%d/%m/%Y")
+
+        return start_datetime, end_datetime

--- a/tests/test_arbitrary_dateparser.py
+++ b/tests/test_arbitrary_dateparser.py
@@ -26,6 +26,19 @@ def test_single_empty():
 
 
 @freeze_time(TESTDRIVE_DATETIME)
+def test_single_relative():
+    dr = DaterangeExpression()
+    assert dr.parse("today") == (
+        dt.datetime(2023, 8, 17, 0, 0, 0),
+        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
+    )
+    assert dr.parse("now") == (
+        dt.datetime(2023, 8, 17, 23, 3, 17),
+        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
+    )
+
+
+@freeze_time(TESTDRIVE_DATETIME)
 def test_range_basics():
     # Make the parser exclusively use `arbitrary-dateparser`.
     from aika.core import adp_parse_english
@@ -63,10 +76,23 @@ def test_range_relative():
 
 
 @freeze_time(TESTDRIVE_DATETIME)
-def test_default_start_time():
+def test_default_start_end_time():
     dr = DaterangeExpression(
         default_start_time=dt.time(hour=9),
         default_end_time=dt.time(hour=17),
+    )
+    assert dr.parse("jul 1 to jul 7") == (
+        dt.datetime(2023, 7, 1, 9, 0),
+        dt.datetime(2023, 7, 7, 17, 0, 0),
+    )
+    assert dr.parse("today") == (
+        dt.datetime(2023, 8, 17, 9, 0, 0),
+        dt.datetime(2023, 8, 17, 17, 0, 0),
+    )
+    # A specific datetime must not be changed through `default_start_time`.
+    assert dr.parse("now") == (
+        dt.datetime(2023, 8, 17, 23, 3, 17),
+        dt.datetime(2023, 8, 17, 17, 0, 0),
     )
     assert dr.parse("tomorrow to next thursday") == (
         dt.datetime(2023, 8, 18, 9, 0, 0),

--- a/tests/test_daterangeparser.py
+++ b/tests/test_daterangeparser.py
@@ -12,33 +12,44 @@ from tests import TESTDRIVE_DATETIME
 @freeze_time(TESTDRIVE_DATETIME)
 def test_range_basics():
     dr = DaterangeExpression()
-    assert dr.parse("jul 1 to jul 7") == (
-        dt.datetime(2023, 7, 1, 0, 0),
-        dt.datetime(2023, 7, 7, 23, 59, 59, 999999),
+    assert (
+        dr.parse("jul 1 to jul 7")
+        == dr.parse("juli 1 bis juli 7")
+        == (
+            dt.datetime(2023, 7, 1, 0, 0),
+            dt.datetime(2023, 7, 7, 23, 59, 59, 999999),
+        )
     )
 
-    assert dr.parse("1-7 july") == (
-        dt.datetime(2023, 7, 1, 0, 0),
-        dt.datetime(2023, 7, 7, 23, 59, 59, 999999),
+    assert (
+        dr.parse("1-7 july")
+        == dr.parse("1.-7. juli")
+        == (
+            dt.datetime(2023, 7, 1, 0, 0),
+            dt.datetime(2023, 7, 7, 23, 59, 59, 999999),
+        )
     )
 
 
 @freeze_time(TESTDRIVE_DATETIME)
 def test_single_basics():
     dr = DaterangeExpression()
-    assert dr.parse("1st july") == (
-        dt.datetime(2023, 7, 1, 0, 0),
-        dt.datetime(2023, 7, 1, 23, 59, 59, 999999),
+    assert (
+        dr.parse("1st july")
+        == dr.parse("1 juli")
+        == dr.parse("1. juli")
+        == (
+            dt.datetime(2023, 7, 1, 0, 0),
+            dt.datetime(2023, 7, 1, 23, 59, 59, 999999),
+        )
     )
-    assert dr.parse("March 2024") == (
-        dt.datetime(2024, 3, 1, 0, 0, 0),
-        dt.datetime(2024, 3, 31, 23, 59, 59, 999999),
-    )
-
-
-@freeze_time(TESTDRIVE_DATETIME)
-    )
-    )
+    assert (
+        dr.parse("March 2024")
+        == dr.parse("März 2024")
+        == (
+            dt.datetime(2024, 3, 1, 0, 0, 0),
+            dt.datetime(2024, 3, 31, 23, 59, 59, 999999),
+        )
     )
 
 
@@ -48,11 +59,31 @@ def test_months():
         default_start_time=dt.time(hour=9),
         default_end_time=dt.time(hour=17),
     )
-    assert dr.parse("March") == (
-        dt.datetime(2023, 3, 1, 9, 0, 0),
-        dt.datetime(2023, 3, 31, 17, 0, 0),
+    assert (
+        dr.parse("March")
+        == dr.parse("Mär")
+        == (
+            dt.datetime(2023, 3, 1, 9, 0, 0),
+            dt.datetime(2023, 3, 31, 17, 0, 0),
+        )
     )
-    assert dr.parse("July to December") == (
-        dt.datetime(2023, 7, 1, 9, 0, 0),
-        dt.datetime(2023, 12, 31, 17, 0, 0),
+    assert (
+        dr.parse("July to December")
+        == dr.parse("Juli bis Dezember")
+        == (
+            dt.datetime(2023, 7, 1, 9, 0, 0),
+            dt.datetime(2023, 12, 31, 17, 0, 0),
+        )
+    )
+
+
+@freeze_time(TESTDRIVE_DATETIME)
+def test_humanized_german():
+    dr = DaterangeExpression(
+        default_start_time=dt.time(hour=9),
+        default_end_time=dt.time(hour=17),
+    )
+    assert dr.parse("Vom 3. März bis zum 9. März 2024") == (
+        dt.datetime(2024, 3, 3, 9, 0, 0),
+        dt.datetime(2024, 3, 9, 17, 0, 0),
     )

--- a/tests/test_daterangeparser.py
+++ b/tests/test_daterangeparser.py
@@ -37,33 +37,8 @@ def test_single_basics():
 
 
 @freeze_time(TESTDRIVE_DATETIME)
-def test_single_relative():
-    dr = DaterangeExpression()
-    assert dr.parse("today") == (
-        dt.datetime(2023, 8, 17, 0, 0, 0),
-        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
     )
-    assert dr.parse("now") == (
-        dt.datetime(2023, 8, 17, 23, 3, 17),
-        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
     )
-
-
-@freeze_time(TESTDRIVE_DATETIME)
-def test_default_start_time():
-    dr = DaterangeExpression(default_start_time=dt.time(hour=9))
-    assert dr.parse("jul 1 to jul 7") == (
-        dt.datetime(2023, 7, 1, 9, 0),
-        dt.datetime(2023, 7, 7, 23, 59, 59, 999999),
-    )
-    assert dr.parse("today") == (
-        dt.datetime(2023, 8, 17, 9, 0, 0),
-        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
-    )
-    # A specific datetime must not be changed through `default_start_time`.
-    assert dr.parse("now") == (
-        dt.datetime(2023, 8, 17, 23, 3, 17),
-        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
     )
 
 


### PR DESCRIPTION
## About

In order to make the library understand natural-language date-/time-range abbreviations in the German language, this patch adds a corresponding implementation for the `DateRangeParser` package.

## Outlook

A bit of code has been duplicated. At least when adding yet another language, it should be refactored more thoroughly.
