### PR TITLE
CI: Run tests on macOS and Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.8", "3.11"]
 
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     env:
       OS: ${{ matrix.os }}
@@ -36,6 +36,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Generate locales
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get update && sudo apt-get install tzdata locales -y && sudo locale-gen de_DE.UTF-8
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,11 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "LGPL 3, EUPL 1.2" }
 keywords = [
-  "open data",
-  "public transport",
-  "routing",
+  "date",
+  "time",
+  "parsing",
+  "utility",
+  "multi-language",
 ]
 authors = [
   {name = "Andreas Motl", email = "andreas.motl@panodata.org"},


### PR DESCRIPTION
## About

On CI, also run software tests on macOS and Windows. Also, run tests on Python 3.8 and 3.11 only, in order to save resources.
