### PR TITLE
CI: Update to codecov-action@v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,4 +71,4 @@ jobs:
         flags: unittests
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: false
+        fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,9 @@ jobs:
         poe check
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
## Background
- https://github.com/panodata/aika/pull/52

## About
> Tokenless uploading is unsupported. However, PRs made from forks to
> the upstream public repos will support tokenless (e.g. contributors to
> OS projects do not need the upstream repo's Codecov token). This doc
> shows instructions on how to add the Codecov token.
>
> -- https://docs.codecov.com/docs/adding-the-codecov-token#github-actions