### PR TITLE
Maintenance: Add support for Python 3.12 (variant)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         # FIXME: Workaround for installing pendulum 2.x on Python 3.12.
         # https://github.com/sdispater/pendulum/issues/454#issuecomment-654096754
         pip install poetry
-        pip install --use-pep517 --prefer-binary --no-build-isolation --editable=.[develop,docs,test]
+        pip install --use-pep517 --prefer-binary --no-build-isolation --editable=.[develop,test]
 
     - name: Run linter and software tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,9 @@ jobs:
         # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
         pip install "setuptools>=64" --upgrade
 
+        # Install `wheel` package.
+        pip install wheel
+
         # Install package in editable mode.
         # FIXME: Workaround for installing pendulum 2.x on Python 3.12.
         # https://github.com/sdispater/pendulum/issues/454#issuecomment-654096754

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,10 @@ jobs:
         pip install "setuptools>=64" --upgrade
 
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable=.[develop,docs,test]
+        # FIXME: Workaround for installing pendulum 2.x on Python 3.12.
+        # https://github.com/sdispater/pendulum/issues/454#issuecomment-654096754
+        pip install poetry
+        pip install --use-pep517 --prefer-binary --no-build-isolation --editable=.[develop,docs,test]
 
     - name: Run linter and software tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
 
     env:
       OS: ${{ matrix.os }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 
 ## in progress
-
+- Maintenance: Add support for macOS, Windows, and Python 3.12
 
 ## 2023-08-23 v0.1.0
 - Initial thing, using `arbitrary-dateparser` and `DateRangeParser` packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ dynamic = [
 [project.optional-dependencies]
 develop = [
   "black<25",
-  "build<2",
   "mypy==1.8.0",
   "poethepoet<1",
   "pyproject-fmt<1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Communications",
   "Topic :: Education",
   "Topic :: Home Automation",


### PR DESCRIPTION
## About

What the title says.

## Details

`pip --no-build-isolation` is needed to install pendulum-2.x on Python 3.12. To make it work, it also needs the `poetry` and `wheel` packages.

- https://github.com/sdispater/pendulum/issues/454#issuecomment-654096754
