### PR TITLE
Feature: Time deltas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,13 @@
 
 ## in progress
 - Maintenance: Add support for macOS, Windows, and Python 3.12 & 3.13
-- Added new "dudp" parser, using `python-dateutil` and `dateparser`
+- dudp-parser: Added new "dudp" parser, using `python-dateutil` and `dateparser`
 - Naming things: Use `TimeIntervalParser`, and return `TimeInterval` objects
 - Improved compatibility and correctness
 - Added support for shorthand notations for weeks, months, years,
   like `2025W01`, `2025M02`, `2025Q03`, `2025`
 - arbitrary-dateparser: Vendorize vanilla version 0.0.4
+- dudp-parser: Added tests and documentation verifying time deltas
 
 ## 2023-08-23 v0.1.0
 - Initial thing, using `arbitrary-dateparser` and `DateRangeParser` packages

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Aika
 
+Time interval parsing utilities for multiple languages.
 
 ## About
 
@@ -51,6 +52,7 @@ a few examples.
 - Year: 2025
 
 ##### Time deltas
+- Day: `-1d`, `-1 day`
 - Week: `-1w`, `-1 week`
 - Month: `-1M`, `-1 month`
 - Year: `-1y`, `-1 year`

--- a/README.md
+++ b/README.md
@@ -44,10 +44,18 @@ a few examples.
 
 #### dateparser
 
+##### Calendar notations
 - Week: 2025W01
 - Month: 2025M02, 2025-02
 - Quarter: 2025Q03
 - Year: 2025
+
+##### Time deltas
+- Week: `-1w`, `-1 week`
+- Month: `-1M`, `-1 month`
+- Year: `-1y`, `-1 year`
+- Quarter: `-3M`, `-3 months`
+- Mixed: `-3d3h5m30s`
 
 #### arbitrary-dateparser » English
 

--- a/aika/core.py
+++ b/aika/core.py
@@ -149,7 +149,7 @@ class TimeIntervalParser:
         interval = None
         if (when.isnumeric() and len(when) == 4) or "year" in when:
             interval = YEARLY
-        elif "M" in when or (when.count("-") == 1):
+        elif "M" in when or (len(when) == 7 and when.count("-") == 1):
             when = when.replace("M", "-")
             interval = MONTHLY
         elif "W" in when:

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -26,3 +26,7 @@
 - Synchronize splitters/separators from both libraries
 - Do not require locales for other languages to be installed.
   If not, handle it gracefully.
+- Use DateTimeRange?
+  https://github.com/panodata/aika/issues/46
+- Use portion?
+  https://github.com/AlexandreDecan/portion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
 
 [project]
 name = "aika"
-description = "Date- and time-range parsing utilities for multiple languages"
+description = "Time interval parsing utilities for multiple languages."
 readme = "README.md"
 keywords = [
   "date parsing",

--- a/tests/test_dudp.py
+++ b/tests/test_dudp.py
@@ -159,3 +159,54 @@ def test_year_next(ti):
         dt.datetime(2024, 1, 1, 0, 0),
         dt.datetime(2024, 12, 31, 23, 59, 59, 999999),
     )
+
+
+@freeze_time(TESTDRIVE_DATETIME)
+def test_delta(ti):
+    """
+    Test time interval deltas lika `-1d`.
+    """
+    assert ti.parse("-3d3h5m30s") == TimeInterval(
+        dt.datetime(2023, 8, 14, 19, 57, 47),
+        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
+    )
+
+    assert ti.parse("-1w") == TimeInterval(
+        dt.datetime(2023, 8, 10, 23, 3, 17),
+        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
+    )
+
+    assert ti.parse("-1 week") == TimeInterval(
+        dt.datetime(2023, 8, 10, 23, 3, 17),
+        dt.datetime(2023, 9, 10, 23, 3, 17),
+    )
+
+    assert ti.parse("-1M") == TimeInterval(
+        dt.datetime(2023, 8, 1, 0, 0),
+        dt.datetime(2023, 9, 1, 0, 0),
+    )
+
+    assert ti.parse("-1 month") == TimeInterval(
+        dt.datetime(2023, 7, 17, 23, 3, 17),
+        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
+    )
+
+    assert ti.parse("-3 M") == TimeInterval(
+        dt.datetime(2023, 8, 3, 0, 0),
+        dt.datetime(2023, 9, 3, 0, 0),
+    )
+
+    assert ti.parse("-3 months") == TimeInterval(
+        dt.datetime(2023, 5, 17, 23, 3, 17),
+        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
+    )
+
+    assert ti.parse("-1y") == TimeInterval(
+        dt.datetime(2022, 8, 17, 23, 3, 17),
+        dt.datetime(2023, 8, 17, 23, 59, 59, 999999),
+    )
+
+    assert ti.parse("-1 year") == TimeInterval(
+        dt.datetime(2022, 8, 17, 23, 3, 17),
+        dt.datetime(2023, 8, 17, 23, 3, 17),
+    )


### PR DESCRIPTION
## About
Time deltas are also supported. This patch validates and demonstrates them.

- Week: `-1w`, `-1 week`
- Month: `-1M`, `-1 month`
- Year: `-1y`, `-1 year`
- Quarter: `-3M`, `-3 months`
- Mixed: `-3d3h5m30s`
