### PR TITLE
Formatting: Add formatter for Opsgenie API query clause

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## in progress
-- Naming things: Rename argument `snap_days` to `snap_hours`
+- Naming things: Renamed argument `snap_days` to `snap_hours`
+- Formatting: Added formatter for Opsgenie API query clause
 
 ## 2025-02-24 v0.2.1
 - Emit better error message when German locales are not installed

--- a/aika/model.py
+++ b/aika/model.py
@@ -60,3 +60,16 @@ class TimeInterval:
         if self.end:
             buffer += f"..{self.end.isoformat()}"
         return buffer
+
+    def opsgenieformat(self) -> str:
+        """
+        Encode as an Opsgenie API range query. DD-MM-YYYY time format.
+        Example: `createdAt >= "24-02-2025T12:24:22" and createdAt <= "24-02-2025T23:59:59"`
+
+        https://support.atlassian.com/opsgenie/docs/search-queries-for-alerts/
+        """
+        opsgenie_datetime_format = "%d-%m-%YT%H:%M:%S"
+        buffer = f'createdAt >= "{self.start.strftime(opsgenie_datetime_format)}"'
+        if self.end:
+            buffer += f' and createdAt <= "{self.end.strftime(opsgenie_datetime_format)}"'
+        return buffer

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,26 @@
+import pytest
+
+from aika import TimeIntervalParser
+
+
+@pytest.fixture
+def interval():
+    tip = TimeIntervalParser()
+    return tip.parse("july 2023")
+
+
+def test_interval_format_iso(interval):
+    assert interval.isoformat() == "2023-07-01T00:00:00/2023-07-31T00:00:00"
+
+
+def test_interval_format_lucene(interval):
+    with pytest.raises(NotImplementedError):
+        interval.luceneformat()
+
+
+def test_interval_format_math(interval):
+    assert interval.mathformat() == "2023-07-01T00:00:00..2023-07-31T00:00:00"
+
+
+def test_interval_format_opsgenie(interval):
+    assert interval.opsgenieformat() == 'createdAt >= "01-07-2023T00:00:00" and createdAt <= "31-07-2023T00:00:00"'


### PR DESCRIPTION
## About

Opsgenie uses the DD-MM-YYYY time format, and the `createdAt` field name.

## Documentation

[Opsgenie: Search queries for alerts](https://support.atlassian.com/opsgenie/docs/search-queries-for-alerts/)

## Review

Please acknowledge, @WalBeh.
